### PR TITLE
Rename library-objects.go to shelf-objects

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -99,10 +99,10 @@ jobs:
                     - repo: kv-objects
                     - repo: kv-value-calculator
                     - repo: kv-web
-                    - repo: library-api
+                    - repo: shelf-api
                     - repo: library-data
-                    - repo: library-objects
-                    - repo: library-web
+                    - repo: shelf-objects
+                    - repo: shelf-web
                     - repo: main-web
                     - repo: model-core
                     - repo: shared-web

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# sweetrpg-library-objects
+# sweetrpg-shelf-objects
 
-[![Unit tests](https://github.com/sweetrpg/library-objects/actions/workflows/python-ci.yml/badge.svg)](https://github.com/sweetrpg/library-objects/actions/workflows/python-ci.yml)
-[![Coverage](https://github.com/sweetrpg/library-objects/blob/develop/coverage.svg)](https://github.com/sweetrpg/library-objects)
-[![PyPI version](https://badgen.net/pypi/v/sweetrpg-library-objects)](https://pypi.org/project/sweetrpg-library-objects)
-[![License](https://img.shields.io/github/license/sweetrpg/library-objects.svg)](https://img.shields.io/github/license/sweetrpg/library-objects.svg)
-[![Issues](https://img.shields.io/github/issues/sweetrpg/library-objects.svg)](https://img.shields.io/github/issues/sweetrpg/library-objects.svg)
-[![PRs](https://img.shields.io/github/issues-pr/sweetrpg/library-objects.svg)](https://img.shields.io/github/issues-pr/sweetrpg/library-objects.svg)
-[![Dependabot](https://badgen.net/github/dependabot/sweetrpg/library-objects)](https://badgen.net/github/dependabot/sweetrpg/library-objects)
+[![Unit tests](https://github.com/sweetrpg/shelf-objects/actions/workflows/python-ci.yml/badge.svg)](https://github.com/sweetrpg/shelf-objects/actions/workflows/python-ci.yml)
+[![Coverage](https://github.com/sweetrpg/shelf-objects/blob/develop/coverage.svg)](https://github.com/sweetrpg/shelf-objects)
+[![PyPI version](https://badgen.net/pypi/v/sweetrpg-shelf-objects)](https://pypi.org/project/sweetrpg-shelf-objects)
+[![License](https://img.shields.io/github/license/sweetrpg/shelf-objects.svg)](https://img.shields.io/github/license/sweetrpg/shelf-objects.svg)
+[![Issues](https://img.shields.io/github/issues/sweetrpg/shelf-objects.svg)](https://img.shields.io/github/issues/sweetrpg/shelf-objects.svg)
+[![PRs](https://img.shields.io/github/issues-pr/sweetrpg/shelf-objects.svg)](https://img.shields.io/github/issues-pr/sweetrpg/shelf-objects.svg)
+[![Dependabot](https://badgen.net/github/dependabot/sweetrpg/shelf-objects)](https://badgen.net/github/dependabot/sweetrpg/shelf-objects)
 
 [![Python](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://img.shields.io/badge/Python-3776AB?style=for-the-badge&logo=python&logoColor=white)
 [![Built with love](https://ForTheBadge.com/images/badges/built-with-love.svg)](https://ForTheBadge.com/images/badges/built-with-love.svg)
 
-Model package for library applications.
+Model package for shelf applications.
 
 ## Models
 
@@ -110,8 +110,8 @@ Model package for library applications.
 
 1. Create a virtual environment
     ```shell
-    python -m venv ~/.virtualenvs/sweetrpg-library-objects
-    source ~/.virtualenvs/sweetrpg-library-objects/bin/activate
+    python -m venv ~/.virtualenvs/sweetrpg-shelf-objects
+    source ~/.virtualenvs/sweetrpg-shelf-objects/bin/activate
     ```
 2. Install requirements
     ```shell
@@ -135,4 +135,4 @@ resolved versions and dependencies.
 
 ## Documentation
 
-Documentation for this package can be found [here](https://sweetrpg.github.io/library-objects).
+Documentation for this package can be found [here](https://sweetrpg.github.io/shelf-objects).

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/sweetrpg/library-objects
+module github.com/sweetrpg/shelf-objects
 
 go 1.23.3
 

--- a/models/shelf.go
+++ b/models/shelf.go
@@ -4,10 +4,10 @@ import (
 	modelcore "github.com/sweetrpg/model-core/models"
 )
 
-// Library model.
-// This model represents a library of RPG resources that belongs to a user.
-type Library struct {
-	ID     string          `bson:"_id" json:"id" jsonapi:"primary,library"`
+// Shelf model.
+// This model represents a shelf of RPG resources that belongs to a user.
+type Shelf struct {
+	ID     string          `bson:"_id" json:"id" jsonapi:"primary,shelf"`
 	UserID string          `bson:"user_id" json:"user_id" jsonapi:"relation,user"`
 	Notes  string          `json:"notes" jsonapi:"attr,notes"`
 	Tags   []modelcore.Tag `json:"tags" jsonapi:"attr,tags"`

--- a/vo/shelf.go
+++ b/vo/shelf.go
@@ -6,7 +6,7 @@ import (
 
 // License value object.
 // This value object is a serializable representation of the License model.
-type LibraryVO struct {
+type ShelfVO struct {
 	ID     string            `json:"id" jsonapi:"primary,license"`
 	UserID string            `bson:"user_id" json:"user_id" jsonapi:"relation,user"`
 	Notes  string            `json:"notes" jsonapi:"attr,notes"`


### PR DESCRIPTION
Renames the module path (`github.com/sweetrpg/library-objects` -> `github.com/sweetrpg/shelf-objects`), the `Library`/`LibraryVO` types to `Shelf`/`ShelfVO`, and README/CI references, following the GitHub repo rename from `library-objects.go` to `shelf-objects.go`.

Part of task group 1 in the linked OpenSpec change.

Ref: sweetrpg/platform#11
OpenSpec change: `openspec/changes/rename-library-to-shelf/proposal.md` (in sweetrpg/platform)